### PR TITLE
Updated to handle delays elsewhere in the code

### DIFF
--- a/Countimer.cpp
+++ b/Countimer.cpp
@@ -149,7 +149,7 @@ void Countimer::countDown()
 	if (_currentCountTime > 0)
 	{
 		callback();
-		_currentCountTime -= _interval;
+		_currentCountTime -= millis() - _previousMillis;
 	}
 	else
 	{
@@ -163,7 +163,7 @@ void Countimer::countUp()
 	if (_currentCountTime < _countTime)
 	{
 		callback();
-		_currentCountTime += _interval;
+		_currentCountTime += millis() - _previousMillis;
 	}
 	else
 	{


### PR DESCRIPTION
I modified the way `countUp` and `countDown` function to subtract off the actual number of ms since the last update, rather than a single `_interval`. This means that the timer still works if `run` is not called as fast as possible. It does mean that the `interval` callback might not fire at precisely the correct time, but it means the timers always run at the correct pace overall (e.g. issue #14).