### PR TITLE
Create library.properties, so the library doesn't appear to be legacy.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,7 @@
+name=Countimer
+version=1.0.0
+author=inflop
+sentence=A simple library for creating timers and counters.
+category=Timing
+url=https://github.com/inflop/Countimer
+architectures=*


### PR DESCRIPTION
I will add the library to the Arduino public library manager.